### PR TITLE
Do not send any data when HTTP body is nil

### DIFF
--- a/script monitor/src/oghb.go
+++ b/script monitor/src/oghb.go
@@ -201,7 +201,13 @@ func doHttpRequest(method string, urlSuffix string, requestParameters map[string
 	}
 	Url.RawQuery = parameters.Encode()
 
-	request, _ := http.NewRequest(method, Url.String(), body)
+	var request *http.Request
+	var _ error
+	if contentParameters == nil {
+		request, _ = http.NewRequest(method, Url.String(), nil)
+	} else {
+		request, _ = http.NewRequest(method, Url.String(), body)
+	}
 	client := getHttpClient(TIMEOUT)
 
 	resp, error := client.Do(request)


### PR DESCRIPTION
This resolves the problems identified in Issue #5, at least for the `-start` directive.